### PR TITLE
akualizácia + návod pre Solr

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,6 @@ Essential Data pracuje s jazykom, s dátami a na zaujímavých projektoch. Pozri
 [aktuálne otvorené pozície](http://www.essential-data.sk/pracujte-pre-nas/) a pracujte v skvelom
 tíme plnom šikovných ľudí.
 
-Použitie - ako lematizátor z príkazového riadku
------------------------------------------------
-
-Takto spustíme fstutils:
-
-```
-java -jar target/fstutils-0.3.2-jar-with-dependencies.jar
-Usage: fstutils lemmatize <path-to-fst> <options>, where options are:
--e: echo when a word is not in the dictionary, e.g. 'foo bar' -> 'foo bar'.
-Without the -e option it is 'foo bar' -> 'bar'
-```
-
-Ak chceme zlematizovať stdin, použitie napr. takto:
-
-```
-java -jar target/fstutils-0.3.2-jar-with-dependencies.jar lemmatize fst/slovaklemma.fst -e
-```
-
-Tento príkaz dá všetky slová, ktoré má v slovníku do základného tvaru, ostatné len vypíše. 
-
-
 Kompilácia
 ----------
 
@@ -50,6 +29,11 @@ Najjednoduchší spôsob skompilovania je pomocou
 ```
 mvn package
 ```
+Možno budete musieť nastaviť premennú prostredia 
+```
+JAVA_HOME=/usr/lib/jvm/java-8-oracle
+```
+alebo obdobne.
 
 Vytvorenie FST súboru
 ---------------------
@@ -58,9 +42,43 @@ Ak chcete vytvoriť FST súbor nanovo, použite:
 
 ```
 wget -O - 'http://korpus.sk/attachments/morphology_database/ma-2015-02-05.txt.xz' | xzcat > morph-sk.txt
-java -cp target/lucene-fst-lemmatizer-0.3.2-jar-with-dependencies.jar sk.essentialdata.lucene.analysis.fst.FSTBuilder morph-sk.txt slovaklemma.fst
-java -cp target/lucene-fst-lemmatizer-0.3.2-jar-with-dependencies.jar sk.essentialdata.lucene.analysis.fst.FSTBuilder morph-sk.txt slovaklemma_ascii.fst --ascii
+java -cp target/lucene-fst-lemmatizer-0.5.0-jar-with-dependencies.jar sk.essentialdata.lucene.analysis.fst.FSTBuilder morph-sk.txt slovaklemma.fst
+java -cp target/lucene-fst-lemmatizer-0.5.0-jar-with-dependencies.jar sk.essentialdata.lucene.analysis.fst.FSTBuilder morph-sk.txt slovaklemma_ascii.fst --ascii
 ```
+
+Použitie - ako lematizátor z príkazového riadku
+-----------------------------------------------
+
+Takto spustíme fstutils:
+
+```
+java -jar target/fstutils-0.5.0-jar-with-dependencies.jar
+Usage: fstutils lemmatize <path-to-fst> <options>, where options are:
+-e: echo when a word is not in the dictionary, e.g. 'foo bar' -> 'foo bar'.
+Without the -e option it is 'foo bar' -> 'bar'
+```
+
+Ak chceme zlematizovať stdin, použitie napr. takto:
+
+```
+java -jar target/fstutils-0.5.0-jar-with-dependencies.jar lemmatize fst/slovaklemma.fst -e
+```
+
+Tento príkaz dá všetky slová, ktoré má v slovníku do základného tvaru, ostatné len vypíše. 
+
+Použitie v SOLR
+---------------
+1. Súbory `target/fstutils-0.5.0-jar-with-dependencies.jar` a `fst/slovaklemma.fst` skopírujte o priečinka `instanceDir/lib` (v štandardnej inštalácii SOLR na Linuxe `instanceDir=/var/solr/data/your-core-name/data`)
+1. V súbore `instanceDir/conf/schema.xml` v oboch sekciách ``analyzer`` nahraďte riadok
+```
+<filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+```
+(alebo obdobný) riadkom
+```
+<filter class="sk.essentialdata.lucene.analysis.fst.FSTTokenFilterFactory" fst="lib/slovaklemma.fst"/>
+```
+Možno budete musieť zadať absolútnu cestu k súboru, napr. `/var/solr/data/your-core-name/lib/slovaklemma.fst`
+1. Reštartujte SOLR a reindexujte obsah
 
 Odkazy
 ------

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <lucene.version>5.1.0</lucene.version>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.source>1.7</maven.compiler.source>
+    <lucene.version>6.4.1</lucene.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <groupId>sk.essentialdata</groupId>
   <artifactId>lucene-fst-lemmatizer</artifactId>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
 
   <dependencies>
     <dependency>
@@ -86,7 +86,7 @@
               <descriptorRefs>
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>
-              <finalName>fstutils-0.4.0</finalName>
+              <finalName>fstutils-0.5.0</finalName>
             </configuration>
             <phase>package</phase>
             <goals>

--- a/src/main/java/sk/essentialdata/lucene/analysis/fst/FSTTokenFilterFactory.java
+++ b/src/main/java/sk/essentialdata/lucene/analysis/fst/FSTTokenFilterFactory.java
@@ -9,22 +9,12 @@ import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 /**
  * TokenFilterFactory that creates instances of {@link sk.essentialdata.lucene.analysis.fst.FSTTokenFilter}.
- * Example config for British English including a custom dictionary, case insensitive matching:
+ * Example config for Slovak including a custom dictionary:
  * <pre class="prettyprint" >
- * &lt;filter class=&quot;solr.HunspellStemFilterFactory&quot;
- *    dictionary=&quot;en_GB&quot;
- *    affix=&quot;en_GB.aff&quot;
- *    ignoreCase=&quot;true&quot; /&gt;</pre>
- * Both parameters dictionary and affix are mandatory.
- * <br/>
- * The parameter ignoreCase (true/false) controls whether matching is case sensitive or not. Default false.
- * <br/>
- * The parameter strictAffixParsing (true/false) controls whether the affix parsing is strict or not. Default true.
- * If strict an error while reading an affix rule causes a ParseException, otherwise is ignored.
- * <br/>
- * Dictionaries for many languages are available through the OpenOffice project.
+ * &lt;filter class=&quot;sk.essentialdata.lucene.analysis.fst.FSTTokenFilterFactory&quot;
+ *    fst=&quot;lib/slovaklemma.fst&quot;</pre>
  *
- * See <a href="http://wiki.apache.org/solr/Hunspell">http://wiki.apache.org/solr/Hunspell</a>
+ * See <a href="https://github.com/essential-data/lucene-fst-lemmatizer">https://github.com/essential-data/lucene-fst-lemmatizer</a>
  *
  * @author miso
  * @date 4/30/14.


### PR DESCRIPTION
Aktualizoval som verziu na Solr 6.4.1 a pridal som návod na použitie v Solr.
Verziu som zvýšil na 0.5.0, snáď je to OK.
Neporadilo sa mi nájsť miesto, kam umiestniť fst súbor. Preto som v schema.xml použil absolútnu cestu, asi by bolo dobré, keby sa uviedlo, kam s ním.